### PR TITLE
Check type of each item in `menu.items`

### DIFF
--- a/src/Plugin.ts
+++ b/src/Plugin.ts
@@ -5,6 +5,7 @@ import type {
 
 import {
   Menu,
+  MenuItem,
   Notice,
   TAbstractFile,
   TFolder
@@ -89,7 +90,7 @@ export class Plugin extends PluginBase<PluginTypes> {
     ];
 
     const localizedTitles = localizationKeys.map((key) => window.i18next.t(key));
-    menu.items = menu.items.filter((item) => !localizedTitles.includes(item.titleEl.textContent ?? ''));
+    menu.items = menu.items.filter((item) => !(item instanceof MenuItem) || !localizedTitles.includes(item.titleEl.textContent ?? ''));
   }
 
   private async initFileExplorerView(): Promise<void> {


### PR DESCRIPTION
It turns out that `menu.items` may contain `MenuSeparator` instances.
<img width="610" height="340" alt="Screenshot from 2025-08-13 22-49-57" src="https://github.com/user-attachments/assets/8a413df0-6d6c-4740-9348-9d7a0b2759bf" />

Without checking the type, it will throw an error.
<img width="920" height="231" alt="Screenshot from 2025-08-13 22-50-19" src="https://github.com/user-attachments/assets/08a8f676-1d22-48f1-9089-a3c6bb9002b0" />
